### PR TITLE
Version 1.2

### DIFF
--- a/mod.lua
+++ b/mod.lua
@@ -36,6 +36,14 @@ function data()
 					tooltip = _("better_signals_target_no_signals_tooltip"),
 					defaultIndex = 2,
 				},
+				{
+					key = "better_signals_qol_delete_signals",
+					name = _("better_signals_qol_delete_signals"),
+					uiType = "CHECKBOX",
+					values = {  _("0"),_("1"),},
+					tooltip = _("better_signals_qol_delete_signals_tooltip"),
+					defaultIndex = 1,
+				},
 			},
 		},
 		runFn = function(settings, modParams)
@@ -54,6 +62,10 @@ function data()
 				-- Only do up to 9 otherwise may have checksum collisions (2nd to last digit in checksum is signal count. So allowed range 1-9 for that)
 				if params["better_signals_target_no_signals"] ~= nil then
 					signals.targetNoToEval = (params["better_signals_target_no_signals"]+3)
+				end
+
+				if params["better_signals_qol_delete_signals"] ~= nil then
+					signals.deleteSignalsOnBulldoze = (params["better_signals_qol_delete_signals"] == 1)
 				end
 			end
 

--- a/res/scripts/nightfury/signals/main.lua
+++ b/res/scripts/nightfury/signals/main.lua
@@ -127,15 +127,20 @@ function signals.recordSignalToBeUpdated(signalPath, signalsToBeUpdated)
 		-- two trains want to update the same signal. Prioritise whichever train is closest to signal
 
 		local existingPath = signalsToBeUpdated[signalKey]
-		if existingPath.placeInPath > signalPath.placeInPath then
+		if existingPath.place_in_path > signalPath.place_in_path then
 			utils.debugPrint("existing replace", signalPath.entity)
 			signalsToBeUpdated[signalKey] = signalPath
-		elseif existingPath.placeInPath == signalPath.placeInPath then
-			-- when both have same place use whichever has green
-			utils.debugPrint("2 trains with same place in", signalPath.entity)
+		elseif existingPath.place_in_path == signalPath.place_in_path then
+			-- when both have same place use whichever has green, or which is closer to the signal
+			utils.debugPrint("2 trains with same place in ", signalPath.entity)
 			if existingPath.signal_state < signalPath.signal_state then
 				utils.debugPrint("existing replace", signalPath.entity)
 				signalsToBeUpdated[signalKey] = signalPath
+			elseif existingPath.signal_state == signalPath.signal_state then
+				if existingPath.dist_from_signal > signalPath.dist_from_signal then
+					utils.debugPrint("existing replace", signalPath.entity)
+					signalsToBeUpdated[signalKey] = signalPath
+				end
 			end
 		else
 			utils.debugPrint("existing remains")

--- a/res/scripts/nightfury/signals/main.lua
+++ b/res/scripts/nightfury/signals/main.lua
@@ -209,6 +209,7 @@ function signals.throwSignalToRed()
 
 					oldConstruction.params.signal_state = 0
 					oldConstruction.params.previous_speed = nil
+					oldConstruction.params.following_signal = nil
 					utils.updateConstruction(oldConstruction, signal.construction)
 				end
 				value.changed = BETTER_SIGNAL_NO_CHANGE

--- a/res/scripts/nightfury/signals/main.lua
+++ b/res/scripts/nightfury/signals/main.lua
@@ -14,17 +14,17 @@ local BETTER_SIGNAL_WAS_CHANGED = 2
 
 local signals = {}
 signals.signals = {}
--- Table holds all placed Signals
-signals.signalObjects = {}
+signals.signalObjects = {} -- Table holds all placed Signals
 signals.viewDistance = 2000
 signals.targetNoToEval = 4
+signals.deleteSignalsOnBulldoze = true
+
 signals.pos = {0,0} -- Updated by event
 signals.posRadius = 1000 -- Updated by event
 signals.cockpitMode = false
 signals.cockpitTrainEntityId = nil
 signals.cockpitModeAtTime = nil -- We lock the cockpit mode for 2 seconds to prevent a race condition 
 -- where a late arriving camera move makes us think we're out of cockpitMode
-signals.deleteSignalsOnBulldoze = true
 
 ----------------------
 --GUI Location Update!
@@ -106,16 +106,13 @@ function signals.computeSignalPaths(trains, trainLocsEdgeIds)
 	local signalsToBeUpdated = {}
 
 	-- Compute signals in path of each train
-	for vehicleId, vehComp in pairs(trains) do
+	for vehicleId, _ in pairs(trains) do
 		utils.debugPrintVehicle(vehicleId)
-
-		local lineName = trainHelper.getLineNameOfVehicle(vehComp)
 		local signalsToEvaluate = signals.targetNoToEval
 
 		local signalPaths = pathEvaluator.evaluate(vehicleId, config_lookAheadEdges, signalsToEvaluate, trainLocsEdgeIds, signals.signalObjects, signals.signals)
 
 		for _, signalPath in ipairs(signalPaths) do
-			signalPath.lineName = lineName.name
 			signals.recordSignalToBeUpdated(signalPath, signalsToBeUpdated)
 		end
 	end
@@ -158,28 +155,15 @@ function signals.updateConstructions(signalsToBeUpdated)
 			local newCheckSum = 0
 			for _, betterSignal in pairs(tableEntry.signals) do
 				signals.signalObjects[signalKey].changed = BETTER_SIGNAL_CHANGED
-				local conSignal = betterSignal.construction
-
-				if conSignal then
-					local oldConstruction = game.interface.getEntity(conSignal)
-					if oldConstruction and oldConstruction.params then
-						oldConstruction.params.previous_speed = signalPath.previous_speed
-						oldConstruction.params.signal_state = signalPath.signal_state
-						oldConstruction.params.signal_speed = signalPath.signal_speed
-						oldConstruction.params.following_signal = signalPath.following_signal
-						oldConstruction.params.paramsOverride = signalPath.paramsOverride
-						oldConstruction.params.showSpeedChange = true
-
-						if signalPath.lineName ~= "ERROR" then
-							oldConstruction.params.currentLine = signalPath.lineName
-						end
-
+				local conEntityId = betterSignal.construction
+				if conEntityId then
+					local proposedConstruction = utils.updateBetterSignalsParamsOnConstruction(conEntityId, signalPath)
+					if proposedConstruction then
 						newCheckSum = signalPath.checksum
 
 						if (not signals.signalObjects[signalKey].checksum) or (newCheckSum ~= signals.signalObjects[signalKey].checksum) then
-							utils.updateConstruction(oldConstruction, conSignal)
-							
-							utils.debugPrint("utils.updateConstruction for ", signalPath.entity, newCheckSum, signals.signalObjects[signalKey].checksum, signalPath.signal_state )
+							utils.updateConstruction(proposedConstruction, conEntityId)
+							utils.debugPrint("utils.updateConstruction for ", signalPath.entity,conEntityId, newCheckSum, signals.signalObjects[signalKey].checksum, signalPath.signal_state )
 						end
 					else
 						print("Couldn't access params")

--- a/res/scripts/nightfury/signals/main.lua
+++ b/res/scripts/nightfury/signals/main.lua
@@ -24,6 +24,7 @@ signals.cockpitMode = false
 signals.cockpitTrainEntityId = nil
 signals.cockpitModeAtTime = nil -- We lock the cockpit mode for 2 seconds to prevent a race condition 
 -- where a late arriving camera move makes us think we're out of cockpitMode
+signals.deleteSignalsOnBulldoze = true
 
 ----------------------
 --GUI Location Update!
@@ -243,7 +244,19 @@ function signals.createSignal(signal, construct, signalType, isAnimated)
 end
 
 function signals.removeSignalBySignal(signal)
+	local signalObj = signals.signalObjects["signal" .. signal]
 	signals.signalObjects["signal" .. signal] = nil
+
+	if signals.deleteSignalsOnBulldoze then
+		local constructionsToRemove = {}
+		if signalObj and signalObj.signals then
+			for _, signalVal in pairs(signalObj.signals) do
+				table.insert(constructionsToRemove, signalVal.construction)
+			end
+
+			utils.bulldozerConstructions(constructionsToRemove)
+		end
+	end
 end
 
 function signals.removeSignalByConstruction(construction)

--- a/res/scripts/nightfury/signals/mainupdate/pathEvaluator.lua
+++ b/res/scripts/nightfury/signals/mainupdate/pathEvaluator.lua
@@ -42,7 +42,7 @@ function pathEvaluator.evaluate(vehicleId,  lookAheadEdges, signalsToEvaluate, t
 
 	---1st evaluation: We split path into blocks protected by signals/end station. Each block starts with a signal
 	local blocksInPath = pathEvaluator.findBlocksInPath(path,lookAheadEdges, signalsToEvaluate, main_signalObjects, main_signals)
-	local blockBehind = pathEvaluator.findBlockBackwards(path,lookAheadEdges, signalsToEvaluate, main_signalObjects, main_signals)
+	local blockBehind = pathEvaluator.findBlockBackwards(path,lookAheadEdges, main_signalObjects, main_signals)
 	local lastSignalState = SIGNAL_STATE_RED
 
 	-- 2nd evaluation: We determine signal states for each main signal and prepare to return as SignalPath
@@ -70,7 +70,6 @@ function pathEvaluator.evaluate(vehicleId,  lookAheadEdges, signalsToEvaluate, t
 		end
 		signalPaths[1].previous_speed = blockBehind.minSpeed
 	end
-
 
 	-- 3rd evaluation create presignals between the main signals. We do this after the 2nd evaluation because 2nd sets following_signal, and previous_speed which we need
 	-- A presignal is just a copy of the main signal it's for
@@ -279,23 +278,20 @@ end
 ---Evaluate the state of a signal. Behind the train
 ---@param path any
 ---@param lookAheadEdges any
----@param signalsToEvaluate any
 ---@param main_signalObjects any -- signals.signalObjects
 ---@param main_signals any -- signals.signals
 ---@return BlockInfo | nil
-function pathEvaluator.findBlockBackwards(path, lookAheadEdges, signalsToEvaluate, main_signalObjects, main_signals)
+function pathEvaluator.findBlockBackwards(path, lookAheadEdges, main_signalObjects, main_signals)
 
 	if path and path.path and #path.path.edges > 2 then
-		-- Going backwards from end to start
-
-		local startPoint = math.max(path.dyn.pathPos.edgeIndex -1, 1)
-		local stopPoint = math.max(1, startPoint - lookAheadEdges /4)
-		local pathIndex = startPoint
+		local startPoint = math.max(path.dyn.pathPos.edgeIndex -1, 1) -- Train location
+		local stopPoint = math.max(1, startPoint - lookAheadEdges /4) -- Start of path.path.edges. Normally a station
 		local blockMinSpeed = 600
-		local presignalsForNextBlock = {}
+		local presignalsForFirstBlock = {}
 		local paramsOverride = nil
 		local speedOverriden = false
-		while true do
+
+		for pathIndex = startPoint, stopPoint, -1 do
 			local currentEdge = path.path.edges[pathIndex]
 			local edgeEntityId = currentEdge.edgeId.entity
 
@@ -309,22 +305,9 @@ function pathEvaluator.findBlockBackwards(path, lookAheadEdges, signalsToEvaluat
 				local speed = math.floor(utils.getEdgeSpeed(currentEdge.edgeId, transportNetwork))
 				blockMinSpeed = math.min(blockMinSpeed, speed)
 			end
-			local potentialSignal = api.engine.system.signalSystem.getSignal(currentEdge.edgeId, currentEdge.dir)
 
-			if pathIndex == stopPoint then
-				-- Adding Trainstations/End of path
-				return {
-					edges = {},
-					signalListEntityId = 0000,
-					hasSwitch = false,
-					isStation = true,
-					edgeEntityIdOn = edgeEntityId,
-					minSpeed = blockMinSpeed,
-					presignalsEntityIds = presignalsForNextBlock, -- Actually for the next block...
-					paramsOverride = paramsOverride,
-					edgeDistCount = 0
-				}
-			elseif potentialSignal and potentialSignal.entity and potentialSignal.entity ~= -1 then
+			local potentialSignal = api.engine.system.signalSystem.getSignal(currentEdge.edgeId, currentEdge.dir)
+			if potentialSignal and potentialSignal.entity and potentialSignal.entity ~= -1 then
 				local signalComponent = api.engine.getComponent(potentialSignal.entity, api.type.ComponentType.SIGNAL_LIST)
 				if signalComponent and signalComponent.signals and #signalComponent.signals > 0 then
 					local signal = signalComponent.signals[1]
@@ -338,18 +321,19 @@ function pathEvaluator.findBlockBackwards(path, lookAheadEdges, signalsToEvaluat
 							isStation = false,
 							edgeEntityIdOn = edgeEntityId,
 							minSpeed = blockMinSpeed,
-							presignalsEntityIds = presignalsForNextBlock, -- Actually for the next block...
+							presignalsEntityIds = presignalsForFirstBlock,
 							paramsOverride = paramsOverride,
 							edgeDistCount = 0
 						}
 					elseif pathEvaluator.isASignal(signal, potentialSignal.entity, main_signalObjects) then
 						-- Presignal/Hybrid in presignal state
-						table.insert(presignalsForNextBlock, potentialSignal.entity)
+						table.insert(presignalsForFirstBlock, potentialSignal.entity)
 					elseif signal.type == SIGNAL_WAYPOINT then
 						-- Params override
 						local name = utils.getComponentProtected(potentialSignal.entity, 63)
 						local values = pathEvaluator.parseName(string.gsub(name.name, " ", ""))
 
+						paramsOverride = values
 						if values.speed then
 							speedOverriden = true
 							blockMinSpeed = values.speed
@@ -357,9 +341,20 @@ function pathEvaluator.findBlockBackwards(path, lookAheadEdges, signalsToEvaluat
 					end
 				end
 			end
-
-			pathIndex = pathIndex - 1
 		end
+
+		-- Adding Trainstations/End of path
+		return {
+			edges = {},
+			signalListEntityId = 0000,
+			hasSwitch = false,
+			isStation = true,
+			edgeEntityIdOn = path.path.edges[stopPoint].edgeId.entity,
+			minSpeed = blockMinSpeed,
+			presignalsEntityIds = presignalsForFirstBlock,
+			paramsOverride = paramsOverride,
+			edgeDistCount = 0
+		}
 	end
 
 	return nil

--- a/res/scripts/nightfury/signals/mainupdate/pathEvaluator.lua
+++ b/res/scripts/nightfury/signals/mainupdate/pathEvaluator.lua
@@ -30,6 +30,8 @@ function pathEvaluator.evaluate(vehicleId,  lookAheadEdges, signalsToEvaluate, t
 	---@field paramsOverride table
 	---@field place_in_path number -- Which number it is from the train's position
 	---@field dist_from_signal number -- Distance from the signal in number of edges
+	---@field showSpeedChange boolean -- Whether to show the speed change on the signal construction
+	---@field is_station boolean -- Whether this signal path is actually a station
 
 	local res = {}
 	local signalPaths = {}
@@ -49,7 +51,7 @@ function pathEvaluator.evaluate(vehicleId,  lookAheadEdges, signalsToEvaluate, t
 	-- Order is important as we add information from previous and following signals to the current signal
 	for i = 1, #blocksInPath, 1 do
 		local nextSignalIsRedWaypoint = pathEvaluator.nextSignalIsRedWaypoint(blocksInPath, i)
-		local signalPath = pathEvaluator.createSignalPath(blocksInPath, i, trainLocsEdgeEntityIds, signalPaths, nextSignalIsRedWaypoint);
+		local signalPath = pathEvaluator.createSignalPath(blocksInPath, i, trainLocsEdgeEntityIds, signalPaths, nextSignalIsRedWaypoint, main_signalObjects)
 		table.insert(signalPaths, signalPath)
 
 		if signalPath.signal_state == SIGNAL_STATE_RED and (blocksInPath[i].hasSwitch or lastSignalState == SIGNAL_STATE_GREEN or nextSignalIsRedWaypoint) then
@@ -121,9 +123,13 @@ function pathEvaluator.createSignalPathForBlockBehindTrain(signalBehind, firstSi
 		signalPath.signal_state = signalState
 		signalPath.signal_speed = signalBehind.minSpeed
 		signalPath.paramsOverride = signalBehind.paramsOverride
+		signalPath.showSpeedChange = true
+		signalPath.following_signal = firstSignalInPath
+		-- is_station and construction_params are not necessary for the first (only apply to following_signal)
+
+		-- Internal
 		signalPath.place_in_path = 0
 		signalPath.dist_from_signal = 0
-		signalPath.following_signal = firstSignalInPath
 		return signalPath
 end
 
@@ -133,8 +139,9 @@ end
 ---@param trainLocsEdgeEntityIds any
 ---@param signalPaths [SignalPath] -- signal paths created so far, used to get info about previous signal
 ---@param nextSignalIsRedWaypoint boolean
+---@param main_signalObjects table
 ---@return SignalPath
-function pathEvaluator.createSignalPath(blocksInPath, idx, trainLocsEdgeEntityIds, signalPaths, nextSignalIsRedWaypoint)
+function pathEvaluator.createSignalPath(blocksInPath, idx, trainLocsEdgeEntityIds, signalPaths, nextSignalIsRedWaypoint, main_signalObjects)
 		local signalAndBlock = blocksInPath[idx]
 
 		local signalState = SIGNAL_STATE_RED
@@ -151,15 +158,31 @@ function pathEvaluator.createSignalPath(blocksInPath, idx, trainLocsEdgeEntityId
 		signalPath.signal_state = signalState
 		signalPath.signal_speed = signalAndBlock.minSpeed
 		signalPath.paramsOverride = signalAndBlock.paramsOverride
-		signalPath.place_in_path = idx
-		signalPath.dist_from_signal = signalAndBlock.edgeDistCount
+		signalPath.is_station = signalAndBlock.isStation
+		signalPath.showSpeedChange = true
+		signalPath.construction_params = pathEvaluator.getFirstConstructionParams(signalAndBlock.signalListEntityId, main_signalObjects)
 
 		if #signalPaths > 0 then
 			local lastSignal = signalPaths[#signalPaths]
 			signalPath.previous_speed = lastSignal.signal_speed
 			lastSignal.following_signal = signalPath
 		end
+
+		-- Internal
+		signalPath.place_in_path = idx
+		signalPath.dist_from_signal = signalAndBlock.edgeDistCount
+
 		return signalPath
+end
+
+function pathEvaluator.getFirstConstructionParams(signalListEntityId, main_signalObjects)
+	local constructionTable = main_signalObjects["signal" .. signalListEntityId]
+	if constructionTable and constructionTable.signals and #constructionTable.signals > 0 then
+		local conSignalId = constructionTable.signals[1].construction
+		return utils.getStaticConstructionParams(conSignalId)
+	end
+
+	return {}
 end
 
 ---First evaluation: We convert path into blocks protected by signals/end station

--- a/res/scripts/nightfury/signals/mainupdate/pathEvaluator.lua
+++ b/res/scripts/nightfury/signals/mainupdate/pathEvaluator.lua
@@ -25,10 +25,11 @@ function pathEvaluator.evaluate(vehicleId,  lookAheadEdges, signalsToEvaluate, t
 	---@field signal_state number
 	---@field signal_speed number
 	---@field following_signal SignalPath
-	---@field previous_speed boolean
+	---@field previous_speed number
 	---@field checksum number
 	---@field paramsOverride table
-	---@field placeInPath number -- Which number it is from the train's position
+	---@field place_in_path number -- Which number it is from the train's position
+	---@field dist_from_signal number -- Distance from the signal in number of edges
 
 	local res = {}
 	local signalPaths = {}
@@ -40,61 +41,64 @@ function pathEvaluator.evaluate(vehicleId,  lookAheadEdges, signalsToEvaluate, t
 	end
 
 	---1st evaluation: We split path into blocks protected by signals/end station. Each block starts with a signal
-	local signalsInPath = pathEvaluator.findSignalsInPath(path,lookAheadEdges, signalsToEvaluate, main_signalObjects, main_signals)
-	local signalBehind = pathEvaluator.findSignalsInPathBackwards(path,lookAheadEdges, signalsToEvaluate, main_signalObjects, main_signals)
+	local blocksInPath = pathEvaluator.findBlocksInPath(path,lookAheadEdges, signalsToEvaluate, main_signalObjects, main_signals)
+	local blockBehind = pathEvaluator.findBlockBackwards(path,lookAheadEdges, signalsToEvaluate, main_signalObjects, main_signals)
+	local lastSignalState = SIGNAL_STATE_RED
 
 	-- 2nd evaluation: We determine signal states for each main signal and prepare to return as SignalPath
 	-- Order is important as we add information from previous and following signals to the current signal
-
-	-- Evaluate signal behind train first so we can add info about it to the first main signal
-	if signalBehind then
-		-- The presignals on the block behind the train are actually for the first signal, copy over presignals to first block if it exists
-		if #signalsInPath > 0 then
-			signalsInPath[1].presignalsEntityIds = signalBehind.presignalsEntityIds
-		end
-
-		local behindTrainSignalPath = pathEvaluator.evaluateSignalBehindTrain(signalBehind)
-		table.insert(signalPaths, behindTrainSignalPath)
-	end
-
-	for i = 1, #signalsInPath, 1 do
-		local nextSignalIsRedWaypoint = pathEvaluator.nextSignalIsRedWaypoint(signalsInPath, i)
-		local prevSignalState = SIGNAL_STATE_RED
-		if #signalPaths > 0 then
-			prevSignalState = signalPaths[#signalPaths].signal_state
-		end
-
-		local signalPath = pathEvaluator.evaluateSignalInFrontOfTrain(signalsInPath, i, trainLocsEdgeEntityIds, signalPaths, nextSignalIsRedWaypoint);
+	for i = 1, #blocksInPath, 1 do
+		local nextSignalIsRedWaypoint = pathEvaluator.nextSignalIsRedWaypoint(blocksInPath, i)
+		local signalPath = pathEvaluator.createSignalPath(blocksInPath, i, trainLocsEdgeEntityIds, signalPaths, nextSignalIsRedWaypoint);
 		table.insert(signalPaths, signalPath)
 
-		if signalPath.signal_state == SIGNAL_STATE_RED and (signalsInPath[i].hasSwitch or prevSignalState == SIGNAL_STATE_GREEN or nextSignalIsRedWaypoint) then
-			-- We stop early on this red because no point in evaluating beyond the switch or we've hit a red after having a green signals. 
+		if signalPath.signal_state == SIGNAL_STATE_RED and (blocksInPath[i].hasSwitch or lastSignalState == SIGNAL_STATE_GREEN or nextSignalIsRedWaypoint) then
+			-- We stop early on this red because no point in evaluating beyond the switch or we've hit a red we can't safely evaluate after
 			-- Note we can't be efficent and just stop when we hit a red as the game tells us the train position with a lag from what is displayed on screen: so we may have multiple red signals before we get our first green signal
 			utils.debugPrint("stopping early")
 			break
 		end
+
+		lastSignalState = signalPath.signal_state
+	end
+
+		-- Evaluate signal behind train first so we can add info about it to the first main signal
+	if blockBehind and #blocksInPath > 0 then
+		-- The presignals on the block behind the train are actually for the first signal, copy over presignals to first block if it exists
+		for key, value in pairs(blockBehind.presignalsEntityIds) do
+			table.insert(blocksInPath[1].presignalsEntityIds, value)
+		end
+		signalPaths[1].previous_speed = blockBehind.minSpeed
 	end
 
 
 	-- 3rd evaluation create presignals between the main signals. We do this after the 2nd evaluation because 2nd sets following_signal, and previous_speed which we need
 	-- A presignal is just a copy of the main signal it's for
-	local mainSignalOffset = signalBehind == nil and 0 or 1
-	for i = 1, #signalPaths - mainSignalOffset, 1 do
-		local signalPath = signalPaths[i + mainSignalOffset]
-		local presignalsTable = signalsInPath[i].presignalsEntityIds
+	for i = 1, #signalPaths, 1 do
+		local signalPath = signalPaths[i]
+		local presignalsTable = blocksInPath[i].presignalsEntityIds
 
 		-- Create presignals
 		for _, entityId in pairs(presignalsTable) do
 			local preSignalTable = utils.deepCopy(signalPath)
 			preSignalTable.entity = entityId
 
-			utils.debugPrint("Pre signal at ", signalsInPath[i].edgeEntityIdOn, preSignalTable.entity, preSignalTable.signal_state, preSignalTable.signal_speed, preSignalTable.hasSwitch, utils.dictToString(signalPath.paramsOverride))
+			utils.debugPrint("Pre signal at ", blocksInPath[i].edgeEntityIdOn, preSignalTable.entity, preSignalTable.signal_state, preSignalTable.signal_speed, preSignalTable.hasSwitch, utils.dictToString(signalPath.paramsOverride))
 			table.insert(res, preSignalTable)
 		end
 
 		-- Don't forget to add in the main signal
-		utils.debugPrint("Main signal at ", signalsInPath[i].edgeEntityIdOn, signalPath.entity, signalPath.signal_state, signalPath.signal_speed, signalsInPath[i].hasSwitch, utils.dictToString(signalPath.paramsOverride))
+		utils.debugPrint("Main signal at ", blocksInPath[i].edgeEntityIdOn, signalPath.entity, signalPath.signal_state, signalPath.signal_speed, blocksInPath[i].hasSwitch, utils.dictToString(signalPath.paramsOverride), signalPath.place_in_path)
 		table.insert(res, signalPath)
+	end
+
+	-- We now add in the signal behind the train as well (if it's not green)
+	if blockBehind and #signalPaths > 0 then
+		local behindTrainSignalPath = pathEvaluator.createSignalPathForBlockBehindTrain(blockBehind, signalPaths[1])
+		if behindTrainSignalPath.signal_state == SIGNAL_STATE_RED then
+			utils.debugPrint("Adding Signal behind train to start of path ", blockBehind.edgeEntityIdOn, behindTrainSignalPath.entity, behindTrainSignalPath.signal_state, behindTrainSignalPath.signal_speed, blockBehind.hasSwitch, utils.dictToString(behindTrainSignalPath.paramsOverride))
+			table.insert(res, 1, behindTrainSignalPath)
+		end
 	end
 
 	-- 4th evaluation: calc checksums. We do in reverse order to include following signal in checksum
@@ -103,7 +107,11 @@ function pathEvaluator.evaluate(vehicleId,  lookAheadEdges, signalsToEvaluate, t
 	return res
 end
 
-function pathEvaluator.evaluateSignalBehindTrain(signalBehind, firstSignalInPath)
+---Creates SignalPath object for the block behind the train
+---@param signalBehind BlockInfo
+---@param firstSignalInPath SignalPath
+---@return SignalPath
+function pathEvaluator.createSignalPathForBlockBehindTrain(signalBehind, firstSignalInPath)
 		local signalState = SIGNAL_STATE_RED
 		if signalBehind.isStation == false then
 			signalState = signalBehind.signalComp.signals[1].state
@@ -114,18 +122,29 @@ function pathEvaluator.evaluateSignalBehindTrain(signalBehind, firstSignalInPath
 		signalPath.signal_state = signalState
 		signalPath.signal_speed = signalBehind.minSpeed
 		signalPath.paramsOverride = signalBehind.paramsOverride
-		signalPath.placeInPath = 0
+		signalPath.place_in_path = 0
+		signalPath.dist_from_signal = 0
 		signalPath.following_signal = firstSignalInPath
 		return signalPath
 end
 
-function pathEvaluator.evaluateSignalInFrontOfTrain(signalsInPath, idx, trainLocsEdgeEntityIds, signalPaths, nextSignalIsRedWaypoint)
-		local signalAndBlock = signalsInPath[idx]
+---Creates SignalPath object and adds info from previous signal if exists
+---@param blocksInPath [BlockInfo]
+---@param idx any
+---@param trainLocsEdgeEntityIds any
+---@param signalPaths [SignalPath] -- signal paths created so far, used to get info about previous signal
+---@param nextSignalIsRedWaypoint boolean
+---@return SignalPath
+function pathEvaluator.createSignalPath(blocksInPath, idx, trainLocsEdgeEntityIds, signalPaths, nextSignalIsRedWaypoint)
+		local signalAndBlock = blocksInPath[idx]
 
 		local signalState = SIGNAL_STATE_RED
-		if signalAndBlock.isStation == false then
-			-- Recalculate signal state to make more signals green
-			signalState = pathEvaluator.recalcSignalState(signalAndBlock, trainLocsEdgeEntityIds, idx==#signalsInPath, signalAndBlock.hasSwitch, nextSignalIsRedWaypoint)
+		if signalAndBlock.isStation then
+			signalState = SIGNAL_STATE_RED
+		elseif pathEvaluator.canRecalcSignalState(idx==#blocksInPath, nextSignalIsRedWaypoint, signalAndBlock) then
+			signalState = pathEvaluator.recalcSignalState(signalAndBlock, trainLocsEdgeEntityIds)
+		else
+			signalState = signalAndBlock.signalComp.signals[1].state
 		end
 
 		local signalPath = {}
@@ -133,7 +152,8 @@ function pathEvaluator.evaluateSignalInFrontOfTrain(signalsInPath, idx, trainLoc
 		signalPath.signal_state = signalState
 		signalPath.signal_speed = signalAndBlock.minSpeed
 		signalPath.paramsOverride = signalAndBlock.paramsOverride
-		signalPath.placeInPath = idx
+		signalPath.place_in_path = idx
+		signalPath.dist_from_signal = signalAndBlock.edgeDistCount
 
 		if #signalPaths > 0 then
 			local lastSignal = signalPaths[#signalPaths]
@@ -150,7 +170,7 @@ end
 ---@param main_signalObjects any -- signals.signalObjects
 ---@param main_signals any -- signals.signals
 ---@return [BlockInfo]
-function pathEvaluator.findSignalsInPath(path, lookAheadEdges, signalsToEvaluate, main_signalObjects, main_signals)
+function pathEvaluator.findBlocksInPath(path, lookAheadEdges, signalsToEvaluate, main_signalObjects, main_signals)
 	---@class BlockInfo Represents a block of track with a signal or a station
 	---@field edges table<number> nil when isStation is true
 	---@field signalComp any
@@ -161,6 +181,7 @@ function pathEvaluator.findSignalsInPath(path, lookAheadEdges, signalsToEvaluate
 	---@field minSpeed number
 	---@field presignalsEntityIds [string]
 	---@field paramsOverride table
+	---@field edgeDistCount number
 
 	local blocks = {}
 	local presignalsForNextBlock = {}
@@ -201,6 +222,7 @@ function pathEvaluator.findSignalsInPath(path, lookAheadEdges, signalsToEvaluate
 					edgeEntityIdOn = edgeEntityId,
 					minSpeed = 0,
 					presignalsEntityIds = presignalsForNextBlock,
+					edgeDistCount = pathIndex - pathStart
 				}
 				table.insert(blocks, stopInfo)
 			elseif potentialSignal and potentialSignal.entity and potentialSignal.entity ~= -1 then
@@ -217,7 +239,8 @@ function pathEvaluator.findSignalsInPath(path, lookAheadEdges, signalsToEvaluate
 							isStation = false,
 							edgeEntityIdOn = edgeEntityId,
 							minSpeed = speed,
-							presignalsEntityIds = presignalsForNextBlock
+							presignalsEntityIds = presignalsForNextBlock,
+							edgeDistCount = pathIndex - pathStart
 						}
 						table.insert(blocks, signalInfo)
 						presignalsForNextBlock = {}
@@ -260,20 +283,19 @@ end
 ---@param main_signalObjects any -- signals.signalObjects
 ---@param main_signals any -- signals.signals
 ---@return BlockInfo | nil
-function pathEvaluator.findSignalsInPathBackwards(path, lookAheadEdges, signalsToEvaluate, main_signalObjects, main_signals)
+function pathEvaluator.findBlockBackwards(path, lookAheadEdges, signalsToEvaluate, main_signalObjects, main_signals)
 
 	if path and path.path and #path.path.edges > 2 then
-		-- Going backwards
-		local pathStart = math.max(path.dyn.pathPos.edgeIndex -1, 1)
-		local pathEnd = math.min(0, pathStart - lookAheadEdges /4)
-		local pathIndex = pathStart
-		local shouldContinueSearch = true
+		-- Going backwards from end to start
+
+		local startPoint = math.max(path.dyn.pathPos.edgeIndex -1, 1)
+		local stopPoint = math.max(1, startPoint - lookAheadEdges /4)
+		local pathIndex = startPoint
 		local blockMinSpeed = 600
 		local presignalsForNextBlock = {}
 		local paramsOverride = nil
 		local speedOverriden = false
-
-		while shouldContinueSearch do
+		while true do
 			local currentEdge = path.path.edges[pathIndex]
 			local edgeEntityId = currentEdge.edgeId.entity
 
@@ -289,7 +311,7 @@ function pathEvaluator.findSignalsInPathBackwards(path, lookAheadEdges, signalsT
 			end
 			local potentialSignal = api.engine.system.signalSystem.getSignal(currentEdge.edgeId, currentEdge.dir)
 
-			if pathEvaluator.isStationOrPathEnd(pathIndex, path, pathEnd) then
+			if pathIndex == stopPoint then
 				-- Adding Trainstations/End of path
 				return {
 					edges = {},
@@ -299,7 +321,8 @@ function pathEvaluator.findSignalsInPathBackwards(path, lookAheadEdges, signalsT
 					edgeEntityIdOn = edgeEntityId,
 					minSpeed = blockMinSpeed,
 					presignalsEntityIds = presignalsForNextBlock, -- Actually for the next block...
-					paramsOverride = paramsOverride
+					paramsOverride = paramsOverride,
+					edgeDistCount = 0
 				}
 			elseif potentialSignal and potentialSignal.entity and potentialSignal.entity ~= -1 then
 				local signalComponent = api.engine.getComponent(potentialSignal.entity, api.type.ComponentType.SIGNAL_LIST)
@@ -316,7 +339,8 @@ function pathEvaluator.findSignalsInPathBackwards(path, lookAheadEdges, signalsT
 							edgeEntityIdOn = edgeEntityId,
 							minSpeed = blockMinSpeed,
 							presignalsEntityIds = presignalsForNextBlock, -- Actually for the next block...
-							paramsOverride = paramsOverride
+							paramsOverride = paramsOverride,
+							edgeDistCount = 0
 						}
 					elseif pathEvaluator.isASignal(signal, potentialSignal.entity, main_signalObjects) then
 						-- Presignal/Hybrid in presignal state
@@ -326,19 +350,14 @@ function pathEvaluator.findSignalsInPathBackwards(path, lookAheadEdges, signalsT
 						local name = utils.getComponentProtected(potentialSignal.entity, 63)
 						local values = pathEvaluator.parseName(string.gsub(name.name, " ", ""))
 
-						paramsOverride = values
-						speedOverriden = true
-
 						if values.speed then
+							speedOverriden = true
 							blockMinSpeed = values.speed
 						end
 					end
 				end
 			end
 
-			if pathEvaluator.isStationOrPathEnd(pathIndex, path, pathEnd) then
-				shouldContinueSearch = false
-			end
 			pathIndex = pathIndex - 1
 		end
 	end
@@ -346,14 +365,12 @@ function pathEvaluator.findSignalsInPathBackwards(path, lookAheadEdges, signalsT
 	return nil
 end
 
-
 function pathEvaluator.isStationOrPathEnd(pathIndex, path, pathEnd)
 	return pathIndex == (#path.path.edges - path.path.endOffset) or pathIndex >= pathEnd
 end
 
 function pathEvaluator.shouldContinueSearching(foundBlocks, signalsToEvaluate, pathIndex, pathEnd, path)
 	if pathEvaluator.isStationOrPathEnd(pathIndex, path, pathEnd) then
-		-- Reached end
 		utils.debugPrint("stopping: path end/Station")
 		return false
 	end
@@ -390,39 +407,46 @@ function pathEvaluator.isAfterSwitch(transportNetwork)
 end
 
 ---The game has signals be default as red. This attempts to return more signals as green
----@param block BlockInfo
+---@param signalAndBlock BlockInfo
 ---@param trainLocsEdgeEntityIds any -- edgeEntityIds of location of nearby trains
----@param isLast boolean -- If last signal that has been evaluated unsafe to treat red as green
----@param protectsSwitch boolean -- If the signal protects a switch
----@param nextSignalIsRedWaypoint boolean -- If the next signal is a red waypoint
 ---@return number -- signal state. 1 is green, 0 is red
-function pathEvaluator.recalcSignalState(block, trainLocsEdgeEntityIds, isLast, protectsSwitch, nextSignalIsRedWaypoint)
-	local signal = block.signalComp.signals[1]
-
-	if signal.state == SIGNAL_STATE_GREEN or isLast or protectsSwitch or nextSignalIsRedWaypoint then
+function pathEvaluator.recalcSignalState(signalAndBlock, trainLocsEdgeEntityIds)
+	local signal = signalAndBlock.signalComp.signals[1]
+	if signal.state == SIGNAL_STATE_GREEN then
 		return signal.state
 	end
 
 	-- Red signal. Let's see if it's safe to treat as green
-	local hasTrainInPath = pathEvaluator.hasTrainInPath(block.edges, trainLocsEdgeEntityIds)
+	local hasTrainInPath = pathEvaluator.hasTrainInPath(signalAndBlock.edges, trainLocsEdgeEntityIds)
 
 	if not hasTrainInPath then
-		utils.debugPrint("Treat red signal as green "  .. block.signalListEntityId)
+		utils.debugPrint("Treat red signal as green "  .. signalAndBlock.signalListEntityId)
 		return SIGNAL_STATE_GREEN
 	else
 		return signal.state
 	end
 end
 
-function pathEvaluator.nextSignalIsRedWaypoint(signalsInPath, curIdx)
-	if curIdx < #signalsInPath then
-		local nextSignalAndBlock = signalsInPath[curIdx+1]
-		if nextSignalAndBlock.isStation == false then
-			local nextSignal = nextSignalAndBlock.signalComp.signals[1]
-			return nextSignal.type == SIGNAL_WAYPOINT and nextSignal.state == SIGNAL_STATE_RED
-		end
+function pathEvaluator.canRecalcSignalState(isLast, nextSignalIsRedWaypoint, signalAndBlock)
+	if isLast or signalAndBlock.hasSwitch or nextSignalIsRedWaypoint or signalAndBlock.isStation then
+		return false
 	end
-	return false
+
+	return true
+end
+
+function pathEvaluator.nextSignalIsRedWaypoint(signalsInPath, curIdx)
+	if curIdx >= #signalsInPath then
+		return false
+	end
+
+	local nextSignalAndBlock = signalsInPath[curIdx+1]
+	if nextSignalAndBlock.isStation == true then
+		return false
+	end
+
+	local nextSignal = nextSignalAndBlock.signalComp.signals[1]
+	return nextSignal.type == SIGNAL_WAYPOINT and nextSignal.state == SIGNAL_STATE_RED
 end
 
 function pathEvaluator.hasTrainInPath(edgesTable, trainLocsEdgeIds)
@@ -484,6 +508,12 @@ function pathEvaluator.parseName(input)
             result[key] = value
         end
     end
+
+		-- Bugfix if speed is not a number things break later
+		if result.speed and type(result.speed) ~= "number" then
+			result.speed = nil
+		end
+
     return result
 end
 

--- a/res/scripts/nightfury/signals/mainupdate/pathEvaluator.lua
+++ b/res/scripts/nightfury/signals/mainupdate/pathEvaluator.lua
@@ -24,7 +24,6 @@ function pathEvaluator.evaluate(vehicleId,  lookAheadEdges, signalsToEvaluate, t
 	---@field entity number Entity from api.engine.system.signalSystem.getSignal(). Should rename but keeping for backwards compatibility
 	---@field signal_state number
 	---@field signal_speed number
-	---@field incomplete boolean
 	---@field following_signal SignalPath
 	---@field previous_speed boolean
 	---@field checksum number
@@ -32,6 +31,7 @@ function pathEvaluator.evaluate(vehicleId,  lookAheadEdges, signalsToEvaluate, t
 	---@field placeInPath number -- Which number it is from the train's position
 
 	local res = {}
+	local signalPaths = {}
 
 	local path = api.engine.getComponent(vehicleId, api.type.ComponentType.MOVE_PATH)
 	-- ignore stopped trains 
@@ -41,40 +41,33 @@ function pathEvaluator.evaluate(vehicleId,  lookAheadEdges, signalsToEvaluate, t
 
 	---1st evaluation: We split path into blocks protected by signals/end station. Each block starts with a signal
 	local signalsInPath = pathEvaluator.findSignalsInPath(path,lookAheadEdges, signalsToEvaluate, main_signalObjects, main_signals)
+	local signalBehind = pathEvaluator.findSignalsInPathBackwards(path,lookAheadEdges, signalsToEvaluate, main_signalObjects, main_signals)
 
 	-- 2nd evaluation: We determine signal states for each main signal and prepare to return as SignalPath
 	-- Order is important as we add information from previous and following signals to the current signal
-	local mainSignals = {}
+
+	-- Evaluate signal behind train first so we can add info about it to the first main signal
+	if signalBehind then
+		-- The presignals on the block behind the train are actually for the first signal, copy over presignals to first block if it exists
+		if #signalsInPath > 0 then
+			signalsInPath[1].presignalsEntityIds = signalBehind.presignalsEntityIds
+		end
+
+		local behindTrainSignalPath = pathEvaluator.evaluateSignalBehindTrain(signalBehind)
+		table.insert(signalPaths, behindTrainSignalPath)
+	end
+
 	for i = 1, #signalsInPath, 1 do
-		local signalAndBlock = signalsInPath[i]
-
 		local nextSignalIsRedWaypoint = pathEvaluator.nextSignalIsRedWaypoint(signalsInPath, i)
-
-		local signalState = SIGNAL_STATE_RED
-		if signalAndBlock.isStation == false then
-			-- Recalculate signal state to make more signals green
-			signalState = pathEvaluator.recalcSignalState(signalAndBlock, trainLocsEdgeEntityIds, i==#signalsInPath, signalAndBlock.hasSwitch, nextSignalIsRedWaypoint)
-		end
-
-		local signalPath = {}
-		signalPath.entity = signalAndBlock.signalListEntityId
-		signalPath.signal_state = signalState
-		signalPath.signal_speed = signalAndBlock.minSpeed
-		signalPath.incomplete = false
-		signalPath.paramsOverride = signalAndBlock.paramsOverride
-		signalPath.placeInPath = i
-
 		local prevSignalState = SIGNAL_STATE_RED
-		if #mainSignals >0 then
-			local lastSignal = mainSignals[#mainSignals]
-			signalPath.previous_speed = lastSignal.signal_speed
-			lastSignal.following_signal = signalPath
-			prevSignalState = lastSignal.signal_state
+		if #signalPaths > 0 then
+			prevSignalState = signalPaths[#signalPaths].signal_state
 		end
 
-		table.insert(mainSignals, signalPath)
+		local signalPath = pathEvaluator.evaluateSignalInFrontOfTrain(signalsInPath, i, trainLocsEdgeEntityIds, signalPaths, nextSignalIsRedWaypoint);
+		table.insert(signalPaths, signalPath)
 
-		if signalState == SIGNAL_STATE_RED and (signalAndBlock.hasSwitch or prevSignalState == SIGNAL_STATE_GREEN or nextSignalIsRedWaypoint) then
+		if signalPath.signal_state == SIGNAL_STATE_RED and (signalsInPath[i].hasSwitch or prevSignalState == SIGNAL_STATE_GREEN or nextSignalIsRedWaypoint) then
 			-- We stop early on this red because no point in evaluating beyond the switch or we've hit a red after having a green signals. 
 			-- Note we can't be efficent and just stop when we hit a red as the game tells us the train position with a lag from what is displayed on screen: so we may have multiple red signals before we get our first green signal
 			utils.debugPrint("stopping early")
@@ -82,10 +75,12 @@ function pathEvaluator.evaluate(vehicleId,  lookAheadEdges, signalsToEvaluate, t
 		end
 	end
 
-	-- 3rd evaluation create presignals between the main signals. We do this after the 2nd evaluation because it 2nd sets following_signal, and previous_speed which we need
+
+	-- 3rd evaluation create presignals between the main signals. We do this after the 2nd evaluation because 2nd sets following_signal, and previous_speed which we need
 	-- A presignal is just a copy of the main signal it's for
-	for i = 1, #mainSignals, 1 do
-		local signalPath = mainSignals[i]
+	local mainSignalOffset = signalBehind == nil and 0 or 1
+	for i = 1, #signalPaths - mainSignalOffset, 1 do
+		local signalPath = signalPaths[i + mainSignalOffset]
 		local presignalsTable = signalsInPath[i].presignalsEntityIds
 
 		-- Create presignals
@@ -105,8 +100,47 @@ function pathEvaluator.evaluate(vehicleId,  lookAheadEdges, signalsToEvaluate, t
 	-- 4th evaluation: calc checksums. We do in reverse order to include following signal in checksum
 	utils.addChecksumToSignals(res)
 
-
 	return res
+end
+
+function pathEvaluator.evaluateSignalBehindTrain(signalBehind, firstSignalInPath)
+		local signalState = SIGNAL_STATE_RED
+		if signalBehind.isStation == false then
+			signalState = signalBehind.signalComp.signals[1].state
+		end
+
+		local signalPath = {}
+		signalPath.entity = signalBehind.signalListEntityId
+		signalPath.signal_state = signalState
+		signalPath.signal_speed = signalBehind.minSpeed
+		signalPath.paramsOverride = signalBehind.paramsOverride
+		signalPath.placeInPath = 0
+		signalPath.following_signal = firstSignalInPath
+		return signalPath
+end
+
+function pathEvaluator.evaluateSignalInFrontOfTrain(signalsInPath, idx, trainLocsEdgeEntityIds, signalPaths, nextSignalIsRedWaypoint)
+		local signalAndBlock = signalsInPath[idx]
+
+		local signalState = SIGNAL_STATE_RED
+		if signalAndBlock.isStation == false then
+			-- Recalculate signal state to make more signals green
+			signalState = pathEvaluator.recalcSignalState(signalAndBlock, trainLocsEdgeEntityIds, idx==#signalsInPath, signalAndBlock.hasSwitch, nextSignalIsRedWaypoint)
+		end
+
+		local signalPath = {}
+		signalPath.entity = signalAndBlock.signalListEntityId
+		signalPath.signal_state = signalState
+		signalPath.signal_speed = signalAndBlock.minSpeed
+		signalPath.paramsOverride = signalAndBlock.paramsOverride
+		signalPath.placeInPath = idx
+
+		if #signalPaths > 0 then
+			local lastSignal = signalPaths[#signalPaths]
+			signalPath.previous_speed = lastSignal.signal_speed
+			lastSignal.following_signal = signalPath
+		end
+		return signalPath
 end
 
 ---First evaluation: We convert path into blocks protected by signals/end station
@@ -127,6 +161,7 @@ function pathEvaluator.findSignalsInPath(path, lookAheadEdges, signalsToEvaluate
 	---@field minSpeed number
 	---@field presignalsEntityIds [string]
 	---@field paramsOverride table
+	---@field isBehindTrain boolean -- Indicates if the block is behind the train
 
 	local blocks = {}
 	local presignalsForNextBlock = {}
@@ -166,7 +201,8 @@ function pathEvaluator.findSignalsInPath(path, lookAheadEdges, signalsToEvaluate
 					isStation = true,
 					edgeEntityIdOn = edgeEntityId,
 					minSpeed = 0,
-					presignalsEntityIds = presignalsForNextBlock
+					presignalsEntityIds = presignalsForNextBlock,
+					isBehindTrain = false,
 				}
 				table.insert(blocks, stopInfo)
 			elseif potentialSignal and potentialSignal.entity and potentialSignal.entity ~= -1 then
@@ -183,7 +219,8 @@ function pathEvaluator.findSignalsInPath(path, lookAheadEdges, signalsToEvaluate
 							isStation = false,
 							edgeEntityIdOn = edgeEntityId,
 							minSpeed = speed,
-							presignalsEntityIds = presignalsForNextBlock
+							presignalsEntityIds = presignalsForNextBlock,
+							isBehindTrain = false
 						}
 						table.insert(blocks, signalInfo)
 						presignalsForNextBlock = {}
@@ -218,6 +255,102 @@ function pathEvaluator.findSignalsInPath(path, lookAheadEdges, signalsToEvaluate
 
 	return blocks
 end
+
+---Evaluate the state of a signal. Behind the train
+---@param path any
+---@param lookAheadEdges any
+---@param signalsToEvaluate any
+---@param main_signalObjects any -- signals.signalObjects
+---@param main_signals any -- signals.signals
+---@return BlockInfo | nil
+function pathEvaluator.findSignalsInPathBackwards(path, lookAheadEdges, signalsToEvaluate, main_signalObjects, main_signals)
+
+	if path and path.path and #path.path.edges > 2 then
+		-- Going backwards
+		local pathStart = math.max(path.dyn.pathPos.edgeIndex -1, 1)
+		local pathEnd = math.min(0, pathStart - lookAheadEdges /4)
+		local pathIndex = pathStart
+		local shouldContinueSearch = true
+		local blockMinSpeed = 600
+		local presignalsForNextBlock = {}
+		local paramsOverride = nil
+		local speedOverriden = false
+
+		while shouldContinueSearch do
+			local currentEdge = path.path.edges[pathIndex]
+			local edgeEntityId = currentEdge.edgeId.entity
+
+			local transportNetwork = utils.getComponentProtected(edgeEntityId, api.type.ComponentType.TRANSPORT_NETWORK)
+			if transportNetwork == nil then
+				utils.debugPrint("Unexpected exit of pathEvaluator.findSignalsInPathBackwards as transport network doesn't exist")
+				return nil
+			end
+
+			if not speedOverriden then
+				local speed = math.floor(utils.getEdgeSpeed(currentEdge.edgeId, transportNetwork))
+				blockMinSpeed = math.min(blockMinSpeed, speed)
+			end
+			local potentialSignal = api.engine.system.signalSystem.getSignal(currentEdge.edgeId, currentEdge.dir)
+
+			if pathEvaluator.isStationOrPathEnd(pathIndex, path, pathEnd) then
+				-- Adding Trainstations/End of path
+				return {
+					edges = {},
+					signalListEntityId = 0000,
+					hasSwitch = false,
+					isStation = true,
+					edgeEntityIdOn = edgeEntityId,
+					minSpeed = blockMinSpeed,
+					presignalsEntityIds = presignalsForNextBlock, -- Actually for the next block...
+					isBehindTrain = true, -- This block is behind the train
+					paramsOverride = paramsOverride
+				}
+			elseif potentialSignal and potentialSignal.entity and potentialSignal.entity ~= -1 then
+				local signalComponent = api.engine.getComponent(potentialSignal.entity, api.type.ComponentType.SIGNAL_LIST)
+				if signalComponent and signalComponent.signals and #signalComponent.signals > 0 then
+					local signal = signalComponent.signals[1]
+
+					if pathEvaluator.isMainSignal(signal, potentialSignal.entity, main_signalObjects, main_signals) then
+						return {
+							edges = {}, -- Don't need to set edges
+							signalComp = signalComponent,
+							signalListEntityId = potentialSignal.entity,
+							hasSwitch = false,
+							isStation = false,
+							edgeEntityIdOn = edgeEntityId,
+							minSpeed = blockMinSpeed,
+							presignalsEntityIds = presignalsForNextBlock, -- Actually for the next block...
+							isBehindTrain = true, -- This block is behind the train
+							paramsOverride = paramsOverride
+						}
+					elseif pathEvaluator.isASignal(signal, potentialSignal.entity, main_signalObjects) then
+						-- Presignal/Hybrid in presignal state
+						table.insert(presignalsForNextBlock, potentialSignal.entity)
+					elseif signal.type == SIGNAL_WAYPOINT then
+						-- Params override
+						local name = utils.getComponentProtected(potentialSignal.entity, 63)
+						local values = pathEvaluator.parseName(string.gsub(name.name, " ", ""))
+
+						paramsOverride = values
+						speedOverriden = true
+
+						if values.speed then
+							blockMinSpeed = values.speed
+						end
+					end
+				end
+			end
+
+			if pathEvaluator.isStationOrPathEnd(pathIndex, path, pathEnd) then
+				shouldContinueSearch = false
+			end
+			pathIndex = pathIndex - 1
+		end
+	end
+
+	return nil
+end
+
 
 function pathEvaluator.isStationOrPathEnd(pathIndex, path, pathEnd)
 	return pathIndex == (#path.path.edges - path.path.endOffset) or pathIndex >= pathEnd

--- a/res/scripts/nightfury/signals/mainupdate/pathEvaluator.lua
+++ b/res/scripts/nightfury/signals/mainupdate/pathEvaluator.lua
@@ -161,7 +161,6 @@ function pathEvaluator.findSignalsInPath(path, lookAheadEdges, signalsToEvaluate
 	---@field minSpeed number
 	---@field presignalsEntityIds [string]
 	---@field paramsOverride table
-	---@field isBehindTrain boolean -- Indicates if the block is behind the train
 
 	local blocks = {}
 	local presignalsForNextBlock = {}
@@ -202,7 +201,6 @@ function pathEvaluator.findSignalsInPath(path, lookAheadEdges, signalsToEvaluate
 					edgeEntityIdOn = edgeEntityId,
 					minSpeed = 0,
 					presignalsEntityIds = presignalsForNextBlock,
-					isBehindTrain = false,
 				}
 				table.insert(blocks, stopInfo)
 			elseif potentialSignal and potentialSignal.entity and potentialSignal.entity ~= -1 then
@@ -219,8 +217,7 @@ function pathEvaluator.findSignalsInPath(path, lookAheadEdges, signalsToEvaluate
 							isStation = false,
 							edgeEntityIdOn = edgeEntityId,
 							minSpeed = speed,
-							presignalsEntityIds = presignalsForNextBlock,
-							isBehindTrain = false
+							presignalsEntityIds = presignalsForNextBlock
 						}
 						table.insert(blocks, signalInfo)
 						presignalsForNextBlock = {}
@@ -302,7 +299,6 @@ function pathEvaluator.findSignalsInPathBackwards(path, lookAheadEdges, signalsT
 					edgeEntityIdOn = edgeEntityId,
 					minSpeed = blockMinSpeed,
 					presignalsEntityIds = presignalsForNextBlock, -- Actually for the next block...
-					isBehindTrain = true, -- This block is behind the train
 					paramsOverride = paramsOverride
 				}
 			elseif potentialSignal and potentialSignal.entity and potentialSignal.entity ~= -1 then
@@ -320,7 +316,6 @@ function pathEvaluator.findSignalsInPathBackwards(path, lookAheadEdges, signalsT
 							edgeEntityIdOn = edgeEntityId,
 							minSpeed = blockMinSpeed,
 							presignalsEntityIds = presignalsForNextBlock, -- Actually for the next block...
-							isBehindTrain = true, -- This block is behind the train
 							paramsOverride = paramsOverride
 						}
 					elseif pathEvaluator.isASignal(signal, potentialSignal.entity, main_signalObjects) then

--- a/res/scripts/nightfury/signals/utils.lua
+++ b/res/scripts/nightfury/signals/utils.lua
@@ -202,13 +202,48 @@ function utils.debugPrint(...)
 	end
 end
 
-
 function utils.debugPrintVehicle(vehicleId)
 	if config_debug then
 		print("----------")
 		local vehNameEnt = api.engine.getComponent(vehicleId, api.type.ComponentType.NAME)
 		print("Vehicle " .. vehicleId .. " Name: " .. vehNameEnt.name)
 	end
+end
+
+local betterSignalsApiProperties = {
+	previous_speed = true,
+	signal_state = true,
+	signal_speed = true,
+	following_signal = true,
+	paramsOverride = true,
+	showSpeedChange = true,
+}
+
+function utils.getStaticConstructionParams(constructionId)
+	local conEntity = game.interface.getEntity(constructionId)
+
+	local paramsTable = {}
+	if conEntity and conEntity.params then
+		for key, value in pairs(conEntity.params) do
+			if not betterSignalsApiProperties[key] then
+				paramsTable[key] = value
+			end
+		end
+	end
+	return paramsTable
+end
+
+function utils.updateBetterSignalsParamsOnConstruction(constructionId, signalPath)
+	local oldConstruction = game.interface.getEntity(constructionId)
+	if oldConstruction and oldConstruction.params then
+		for key, _ in pairs(betterSignalsApiProperties) do
+			oldConstruction.params[key] = signalPath[key]
+		end
+	else
+		return nil
+	end
+
+	return oldConstruction
 end
 
 return utils

--- a/res/scripts/nightfury/signals/utils.lua
+++ b/res/scripts/nightfury/signals/utils.lua
@@ -33,6 +33,30 @@ function utils.getComponentProtected(entityId, componentId)
 	end
 end
 
+---Bulldozers list of constructions
+---@param consEntityIds table vector of entity ids to remove
+function utils.bulldozerConstructions(consEntityIds)
+	local toRemove = {}
+	for _, consEntity in pairs(consEntityIds) do
+		if api.engine.entityExists(consEntity) then
+			table.insert(toRemove, consEntity)
+		end
+	end
+
+	if #toRemove == 0 then
+		return
+	end
+
+	local proposal = api.type.SimpleProposal.new()
+	proposal.constructionsToRemove = toRemove
+
+	api.cmd.sendCommand(api.cmd.make.buildProposal(proposal, nil, false), function(res, success)
+		if not success then
+			print(res.resultProposalData.errorState.messages[1] .. " - " .. toRemove[1])
+		end
+	end)
+end
+
 -- Update existing construction
 -- @param params parameter by which the new construction should be build
 -- @param reference is a reference to the old entity. This is used to check if the new entity still holds the same id as before

--- a/strings.lua
+++ b/strings.lua
@@ -21,6 +21,9 @@ return {
 		
 		["better_signals_tunnel_helper"] = ("Tunnel Hilfe"),
 		["better_signals_tunnel_helper_tooltip"] = ("Eine Hilfe, welche das Platzieren von Signalen in Tunnels vereinfachen soll."),
+
+		["better_signals_qol_delete_signals"] = ("Experimentell: Entferne Signale beim Gleis-/Signalabriss"),
+		["better_signals_qol_delete_signals_tooltip"] = ("Experimentell: Entferne das Better-Signal-Asset, wenn das Gleis oder Signal, an dem es befestigt ist, abgerissen wird."),
 	},
 	en = {
 		["nighty_no"] = ("Off"),
@@ -42,6 +45,9 @@ return {
 		
 		["better_signals_tunnel_helper"] = ("Tunnel Helper"),
 		["better_signals_tunnel_helper_tooltip"] = ("Check to enable a helper for placing signals in tunnels"),
+
+		["better_signals_qol_delete_signals"] = ("Experimental: Remove on track/signal bulldozer"),
+		["better_signals_qol_delete_signals_tooltip"] = ("Experimental: Remove the better signal asset when the track or signal it is attached to is bulldozed."),
 	}
 }
 end


### PR DESCRIPTION
- Compute the first signal behind the train [Out of scope from last release]
- Add the construction param configuration to the readable values on following signal [Feature]
- QOL: Remove construction/asset when track or signal is deleted. This may accidentally remove the wrong signal on switches [Feature]
- Bugfixes
  - Fix error that occurs when the param override for speed is not a number
  - Update the api values to match the reference here: https://github.com/nighty34/better-signals/wiki/Reference (remove `currentLine`, add `is_station`)
- Code cleanup including: remove following signals from construction when throw signal to red